### PR TITLE
fix(ci): upgrade Go version, fix goose install and db migration path

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -41,13 +41,13 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@v4
         with:
-          go-version: '1.20'
+          go-version: '1.23'
 
       - name: Install golang-goose
-        run: go install github.com/pressly/goose/v3/cmd/goose@1.23
+        run: go install github.com/pressly/goose/v3/cmd/goose@latest
 
       - name: Run migrations
-        run: goose postgres postgresql://root:secret@localhost:5432/simple_bank up
+        run: goose -dir db/migration postgres postgresql://root:secret@localhost:5432/simple_bank up
 
       - name: Test
         run: go test -v ./...


### PR DESCRIPTION
workflow vory vory bad. version pinning required

Ref: https://github.com/pressly/goose/blob/main/CHANGELOG.md#v3242
from goose docs:
<img width="654" height="124" alt="{95C662A8-FBBB-4C00-8713-64F1C7C571D5}" src="https://github.com/user-attachments/assets/6df886d7-f6bc-4eac-888f-5053914b8e9a" />
